### PR TITLE
change 'website' changeset tag to 'host'

### DIFF
--- a/osm_revert/main.py
+++ b/osm_revert/main.py
@@ -225,7 +225,7 @@ def main(
 
         print(f'🌍️ Uploading {invert_size} change{"s" if invert_size > 1 else ""}')
 
-        extra_args = {'changesets_count': user_edits + 1, 'created_by': CREATED_BY, 'website': WEBSITE}
+        extra_args = {'changesets_count': user_edits + 1, 'created_by': CREATED_BY, 'host': WEBSITE}
 
         if len(changeset_ids) == 1:
             extra_args['id'] = ';'.join(f'https://www.openstreetmap.org/changeset/{c}' for c in changeset_ids)


### PR DESCRIPTION
The most common key for a web editor's host is [`host=`](https://wiki.openstreetmap.org/wiki/Key:host). Neither is `website=` described in [the wiki](https://wiki.openstreetmap.org/wiki/Key:website) to be used within changeset tags, nor is it used by any other editor in this manner.

Changing the changeset tag would be beneficial for the unification of changeset tags and ease understandibility.