### PR TITLE
better message about tag value trimming

### DIFF
--- a/osm_revert/osm.py
+++ b/osm_revert/osm.py
@@ -191,7 +191,7 @@ class OsmApi:
             # trim value if too long
             if len(value) > TAG_MAX_LENGTH:
                 context_print(
-                    f'🚧 Warning: Trimming {key} value because it exceeds {TAG_MAX_LENGTH} characters: {value}'
+                    f'✂️ Trimming value of {key} changeset tag because it exceeds {TAG_MAX_LENGTH} characters: {value}'
                 )
                 extra_tags[key] = value[:252] + '…'
 


### PR DESCRIPTION
Today I received this log:

```
🔒️ Logging in to OpenStreetMap
👤 Welcome, TrickyFoxy!
☁️ Downloading changeset 176713906
[1/?] OpenStreetMap …
[1/2] OpenStreetMap: 589 elements
[2/2] Overpass (1 partition) …
[2/2] Partition #1: OK
[2/2] Overpass: 201 elements (🪣 filtered)
🔁 Generating a revert
🌍️ Uploading 201 changes
🚧 Warning: Trimming revert:filter value because it exceeds 255 characters: way(id:30182217,30272990,30416558,30416560,30416561,30416562,30416569,30416577,30424977,229584998,229585000,229585003,229585004,229585005,386284735,590244402,767788223,767797676,768038037,768038908,1462389708,1462391706,1462392130,1462392153,1462392269,1462392391,1462392681,1462389088,228927759,758874997);
😵 Failed to upload the changes (412)
😵 Precondition failed: Way 758874997 requires the nodes with id in 13414016836, which either do not exist, or are not visible.
🏁 Total time: 14.8 sec
Exit code: -1
```

I incorrectly thought for a while that the revert error was related to a long filter and some Overpass restrictions. But in fact, this is a completely harmless warning about the tag length in OSM. I suggest a different template:

```python
f'✂️ Trimming value of {key} changeset tag because it exceeds {TAG_MAX_LENGTH} characters: {value}'
```
